### PR TITLE
Corrected compile errors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,3 @@
-Copyright 2020 PDFTron Systems Inc. All rights reserved.
-WebViewer React UI project/codebase or any derived works is only permitted in solutions with an active commercial PDFTron WebViewer license. For exact licensing terms please refer to your commercial WebViewer license. For use in other scenario, please contact sales@pdftron.com
+Copyright 2023 Apryse Software Inc. All rights reserved.
+WebViewer React UI project/codebase or any derived works is only permitted in solutions with an active commercial Apryse WebViewer license. For exact licensing terms refer to your commercial WebViewer license. For use in other scenario, contact sales@apryse.com.
+

--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # WebViewer - React - Dropzone sample
 
-[WebViewer](https://www.pdftron.com/documentation/web/) is a powerful JavaScript-based PDF Library that's part of the [PDFTron PDF SDK](https://www.pdftron.com). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate and manipulate PDFs that can be embedded into any web project.
+[WebViewer](https://www.pdftron.com/webviewer) is a powerful JavaScript-based PDF Library that is part of the [Apryse SDK](https://www.pdftron.com). It provides a slick out-of-the-box responsive UI that interacts with the core library to view, annotate, and manipulate PDFs that can be embedded into any web project.
 
-You can [watch a video](https://youtu.be/ZKt38W7Ro4Y) that walks through the demo of this app.
+You can [watch a video](https://youtu.be/ZKt38W7Ro4Y) that demonstrates the app from the end-user’s perspective.
 
-![WebViewer UI](https://github.com/PDFTron/webviewer-document-merge/blob/master/screen2.png)
+![WebViewer UI](screen2.png)
 
-This repo is specifically designed for any users interested in implementing a dropzone where users can drag and drop thumbnails from the two viewers and download the resulting file. 
+This repo is specifically designed for any user interested in implementing a drop zone, where users can drag and drop thumbnails from two viewers and download the resulting file. 
 
 ## Initial setup
 
-Before you begin, make sure your development environment includes [Node.js](https://nodejs.org/en/).
+1. [Node.js](https://nodejs.org/en).
+2. IDE used in this sample is Visual Studio Code with NPM commands within its terminal.
+3. [GitHub command line](https://github.com/git-guides/install-git) `git`.
+
 
 ## Install
 
@@ -30,14 +33,24 @@ Run `npm run build` to build the project. The build artifacts will be stored in 
 
 To test the build directory locally you can use [serve](https://www.npmjs.com/package/serve) or [http-server](https://www.npmjs.com/package/http-server). In case of serve, by default it strips the .html extension stripped from paths. We added serve.json configuration to disable cleanUrls option. 
 
+
+
+Visit PDFTron's [WebViewer](https://docs.apryse.com/documentation/web/) page to see what else you can do with the WebViewer!
+
 ## WebViewer APIs
 
-See [API documentation](https://www.pdftron.com/documentation/web/guides/ui/apis).
+* [API documentation](https://docs.apryse.com/api/web/WebViewerInstance.html)
+* [@pdftron/webviewer-react API documentation](https://github.com/ApryseSDK/webviewer-react)
+
+## Showcase
+
+Refer to a running sample on Apryse SDK [showcase page](https://showcase.apryse.com/).
 
 ## Contributing
 
-See [contributing](./CONTRIBUTING.md).
+Any submission to this repo is governed by these [guidelines](/CONTRIBUTING.md).
+
 
 ## License
 
-See [license](./LICENSE).
+For licensing, refer to [License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This repo is specifically designed for any user interested in implementing a dro
 ## Install
 
 ```
+gh repo clone ApryseSDK/webviewer-document-merge
+cd webviewer-angularjs-sample
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "fs-extra": "^7.0.1"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
+    "start": "SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
+    "build": "SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts build",
+    "test": "SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts test",
+    "eject": "SET NODE_OPTIONS=--openssl-legacy-provider && react-scripts eject",
     "postinstall": "node tools/copy-webviewer-files.js"
   },
   "eslintConfig": {

--- a/src/components/Dropzone/Dropzone.js
+++ b/src/components/Dropzone/Dropzone.js
@@ -90,7 +90,7 @@ const Dropzone = () => {
       </div>
       <div className="list" ref={fileListRef}>
         {thumbArray.map((thumb, i) => {
-          return <img key={i} src={thumb.toDataURL()} />
+          return <img key={i} src={thumb.toDataURL()} alt={i} />
         })}
       </div>
     </div>


### PR DESCRIPTION
1. LICENSE: Updated contents to the latest version.
2. `package.json`: Added scripts to make NodeJS backward compatible with `SET NODE_OPTIONS=--openssl-legacy-provider`.
3. README: updated to use Apryse links and added links to other resources, updated contents.
4. `Dropzone.js` updated to correct an error on the `img` tag is it was missing the `alt' attribute.